### PR TITLE
Fix a bug in examples/wumpus.p4

### DIFF
--- a/examples/wumpus.p4
+++ b/examples/wumpus.p4
@@ -286,7 +286,7 @@ CREATE shoot-path 5 CELLS ALLOT
 ;
 
 : shoot-distance ( -- dist )
-	BEGIN
+	0 BEGIN ( dist-wrong ) DROP
 	  ." NO. OF ROOMS(1-5) " PAD /PAD ACCEPT \ S: len
 	  DROP 0 S>D PAD /PAD >NUMBER 2DROP D>S	\ S: dist
 	  DUP 1 6 WITHIN			\ S: dist bool
@@ -294,7 +294,7 @@ CREATE shoot-path 5 CELLS ALLOT
 ;
 
 : shoot-room ( -- room )
-	BEGIN
+	0 BEGIN ( room-wrong ) DROP
 	  ." ROOM# " PAD /PAD ACCEPT		\ S: len
 	  DROP 0 S>D PAD /PAD >NUMBER 2DROP D>S	\ S: room
 	  DUP 1 max_rooms WITHIN		\ S: room bool


### PR DESCRIPTION
This fixed a bug in `shoot-distance` and `shoot-room`: if the input is not a number or out of the range, then an excessive number is left on the stack in the loop.