### PR TITLE
Fix `default-base-path`

### DIFF
--- a/src/post4.p4
+++ b/src/post4.p4
@@ -2026,7 +2026,7 @@ file-path default-base-path
 
 \ Save the default-base-path to the current working directory.
 getcwd default-base-path DROP CELL- ! DUP default-base-path strncpy FREE DROP
-default-base-path + 1- C@ '/' <> [IF] \ the directory does not ends with "/"
+default-base-path + 1- C@ '/' <> [IF] \ the directory does not end with "/"
 default-base-path  OVER CELL- 1 SWAP +! + '/' OVER c!  1+ 0 SWAP C!
 [THEN]
 

--- a/src/post4.p4
+++ b/src/post4.p4
@@ -2019,13 +2019,16 @@ VARIABLE SCR
 256 CONSTANT path_max
 
 \ (S: <spaces>name -- )
-: file-path CREATE 0 , 0 , path_max ALLOT DOES> @+ ;
+: file-path CREATE 0 , 0 , path_max 1+ ALLOT DOES> @+ ;
 
 \ (S: -- sd.path )
 file-path default-base-path
 
 \ Save the default-base-path to the current working directory.
 getcwd default-base-path DROP CELL- ! DUP default-base-path strncpy FREE DROP
+default-base-path + 1- C@ '/' <> [IF] \ the directory does not ends with "/"
+default-base-path  OVER CELL- 1 SWAP +! + '/' OVER c!  1+ 0 SWAP C!
+[THEN]
 
 2variable (source-base-path)
 


### PR DESCRIPTION
If `source-base-path` (and then `default-base-path`) returns the path of a directory, this path shall end with the forward slash `/`. Because that's how the Base URI and Relative Resolution behave.

Currently, `default-base-path` returns a correct path only if the working directory is the root directory.  Because only in this case `getcwd` returns a path ending with  `"/"`.

This is a quick and dirty fix. It adds the slash at the end if it is missing.
